### PR TITLE
Added pollStreamForeverSafe variant which returns a Result to handle …

### DIFF
--- a/src/FSharp.Control.Redis.Streams.Reactive/FSharp.Control.Redis.Streams.Reactive.fs
+++ b/src/FSharp.Control.Redis.Streams.Reactive/FSharp.Control.Redis.Streams.Reactive.fs
@@ -58,6 +58,35 @@ module Reactive =
         }) (startingPosition, TimeSpan.Zero)
         |> Observable.collect id
 
+    let pollStreamForeverSafe (redisdb : IDatabase) (streamName : RedisKey) (startingPosition : RedisValue) (pollOptions : PollOptions) =
+        Observable.taskUnfold (fun (nextPosition, pollDelay) ct -> task {
+            let! (response : Result<StreamEntry [], exn>) = task {
+                try
+                    let! response = redisdb.StreamRangeAsync(streamName, minId = Nullable(nextPosition), count = (Option.toNullable pollOptions.CountToPullATime))
+                    return Ok response
+                with e ->
+                    return Error e
+            }
+            match response with
+            | Error exn ->
+                let nextPollDelay = pollOptions.CalculateNextPollDelay pollDelay
+                do! Task.Delay pollDelay
+                return Some ((nextPosition, nextPollDelay ) , Error exn)
+            | Ok EmptyArray ->
+                let nextPollDelay = pollOptions.CalculateNextPollDelay pollDelay
+                do! Task.Delay pollDelay
+                return Some ((nextPosition, nextPollDelay ) , Ok Array.empty )
+            | Ok entries ->
+                let lastEntry = Seq.last entries
+                let nextPosition = EntryId.CalculateNextPositionIncr lastEntry.Id
+                let nextPollDelay = TimeSpan.Zero
+                return Some ((nextPosition, nextPollDelay), Ok entries )
+
+        }) (startingPosition, TimeSpan.Zero)
+        |> Observable.collect (function
+            | Ok entries -> entries |> Array.map Ok
+            | Error exn -> [|Error exn|])
+
     let readFromStream (redisdb : IDatabase) (streamRead : ReadStreamConfig) =
         let readForward (newMinId : RedisValue) =
             redisdb.StreamRangeAsync(


### PR DESCRIPTION
Fixes https://github.com/TheAngryByrd/FSharp.Control.Redis.Streams/issues/2

…Redis polling exceptions.

For each streams (Akka, Hopac, Observable) adding a pollstreamForeverSafe variant which returns Result to handle polling specific exception and also allows to resume for where previously left off instead of terminating the stream.

## Types of changes

What types of changes does your code introduce to FSharp.Control.Redis.Streams?

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

